### PR TITLE
Fix command injection vulnerability in test.yaml

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,12 +49,14 @@ jobs:
       - name: Install Python requirements
         run:
           pip install -r tests/requirements.txt
-
+          
       - name: Download HAOS image
         if: ${{ !inputs.use-artifact }}
+        env:
+          VERSION: ${{ github.event.inputs.version }}
         run: |
-          curl -sfL -o haos.qcow2.xz  https://os-artifacts.home-assistant.io/${{github.event.inputs.version}}/haos_ova-${{github.event.inputs.version}}.qcow2.xz
-
+          curl -sfL -o haos.qcow2.xz "https://os-artifacts.home-assistant.io/${VERSION}/haos_ova-${VERSION}.qcow2.xz"
+          
       - name: Get OS image artifact
         if: ${{ inputs.use-artifact }}
         uses: actions/download-artifact@v4


### PR DESCRIPTION
While looking into the GitHub Actions workflows for the Home Assistant Operating System I found an example of Command Injection Vulnerability on their testing pipeline. The User input (OS version number) was fed directly (via GitHubs ${{ }} capability) into a bash script thereby allowing any malicious User to pass a version number with any shell command (like a semicolon or backtick) in it to escape from the intended bash script being executed and run their own code on the build machine.
In order to mitigate this risk, I submitted a security patch that updated the workflow to follow secure coding best practices. Rather than interpolate the untrusted input directly into the command line when executing the bash file, I bound the untrusted input to a secure environment variable and allowed the shell to interpret the input as just a data string, removing the risk of arbitrary code execution. The tests continue to run as before.